### PR TITLE
27 backend for cloudinary

### DIFF
--- a/Controllers/CloudinaryController.cs
+++ b/Controllers/CloudinaryController.cs
@@ -1,0 +1,37 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/[controller]")]
+public class UploadController : ControllerBase
+{
+    private readonly CloudinaryService _cloudinaryService;
+
+    public UploadController(CloudinaryService cloudinaryService)
+    {
+        _cloudinaryService = cloudinaryService;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> UploadImage([FromForm] IFormFile file, [FromForm] string type)
+    {
+        // If no file, no luck
+        if (file == null || file.Length == 0)
+        {
+            return BadRequest("No file provided.");
+        }
+
+        using var stream = file.OpenReadStream();
+        // If `type` is null or empty, it’ll fall back to the default transformation
+        var imageUrl = await _cloudinaryService.UploadImageAsync(stream, file.FileName, type);
+
+        if (string.IsNullOrEmpty(imageUrl))
+        {
+            return StatusCode(500, "Cloudinary upload failed.");
+        }
+
+        // Return the URL as JSON
+        return Ok(new { imageUrl });
+    }
+}

--- a/Controllers/PostContoller.cs
+++ b/Controllers/PostContoller.cs
@@ -76,8 +76,6 @@ public class PostController : ControllerBase
         return Ok(posts);
     }
 
-
-
     [HttpGet("{id}")]
     [Authorize]
     public IActionResult GetById(int id)
@@ -149,6 +147,7 @@ public class PostController : ControllerBase
             AuthorId = postDTO.AuthorId,
             PublishingDate = DateTime.Now,
             SubTitle = postDTO.SubTitle,
+            HeaderImage = postDTO.HeaderImage,
             IsApproved = true,
         };
 

--- a/Controllers/UserProfileController.cs
+++ b/Controllers/UserProfileController.cs
@@ -149,7 +149,6 @@ public class UserProfileController : ControllerBase
     //[Authorize]
     public IActionResult GetUserProfilesPost(int id)
     {
-
         var posts = _dbContext
             .Posts.Include(p => p.Author)
             .Include(p => p.Category)
@@ -169,5 +168,27 @@ public class UserProfileController : ControllerBase
             .ToList();
 
         return Ok(posts);
+    }
+
+    [HttpPut("{id}/image")]
+    [Authorize]
+    public IActionResult UpdateUserProfileImage(int id, [FromBody] UserProfileDTO dto)
+    {
+        // 1. Find the user by ID
+        var userProfile = _dbContext.UserProfiles.SingleOrDefault(up => up.Id == id);
+
+        if (userProfile == null)
+        {
+            return NotFound("UserProfile not found.");
+        }
+
+        // 2. Update only the ImageLocation property
+        userProfile.ImageLocation = dto.ImageLocation;
+
+        // 3. Save changes
+        _dbContext.SaveChanges();
+
+        // 4. Return success response
+        return NoContent();
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -19,6 +19,8 @@ builder
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+// Register your CloudinaryService
+builder.Services.AddScoped<CloudinaryService>();
 builder
     .Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
     .AddCookie(

--- a/Services/CloudinaryService.cs
+++ b/Services/CloudinaryService.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using System.Threading.Tasks;
+using CloudinaryDotNet;
+using CloudinaryDotNet.Actions;
+using Microsoft.Extensions.Configuration;
+
+public class CloudinaryService
+{
+    private readonly Cloudinary _cloudinary;
+
+    public CloudinaryService(IConfiguration config)
+    {
+        var account = new Account(
+            config["Cloudinary:CloudName"], // e.g. "dvp4wikev"
+            config["Cloudinary:ApiKey"], // e.g. "862394414244217"
+            config["Cloudinary:ApiSecret"] // e.g. "loiWCtS2UcJzA-Fzwh9-j2d0lFU"
+        );
+        _cloudinary = new Cloudinary(account);
+    }
+
+    public async Task<string> UploadImageAsync(
+        Stream imageStream,
+        string fileName,
+        string imageType
+    )
+    {
+        var uploadParams = new ImageUploadParams
+        {
+            File = new FileDescription(fileName, imageStream),
+            Transformation = GetTransformation(imageType),
+        };
+
+        var result = await _cloudinary.UploadAsync(uploadParams);
+        return result.SecureUrl?.ToString();
+    }
+
+    private Transformation GetTransformation(string imageType)
+    {
+        // Return a transformation based on the image type
+        return imageType switch
+        {
+            // Profile pictures: 500x500, fill-crop around the face
+            "profile" => new Transformation().Width(500).Height(500).Crop("fill").Gravity("face"),
+
+            // Header images: 1200x400, fill-crop for wide layouts
+            "header" => new Transformation().Width(1200).Height(400).Crop("fill"),
+
+            // Default fallback
+            _ => new Transformation().Width(800).Height(600).Crop("limit"),
+        };
+    }
+}

--- a/Tabloid.csproj
+++ b/Tabloid.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CloudinaryDotNet" Version="1.27.4" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION


## **Description**  
This PR implements **Cloudinary image upload support** for user profile pictures. The backend now includes:  

- **A new `PUT /api/UserProfile/{id}/image` endpoint**  
  - Accepts `{ "imageLocation": "<cloudinary-url>" }` in the request body.  
  - Updates `UserProfile.ImageLocation` for the specified user.  
- **Cloudinary credentials are now stored in .NET User Secrets**  
  - Credentials are no longer in `appsettings.json` or `launchSettings.json`.  
  - You’ll need to set them up manually (see instructions below).  
- **No model changes were made**, so no migrations are required.

### **What You Need to Do**  

1. **Pull the latest changes from this branch.**  
2. **Run `dotnet restore`** to ensure you have all dependencies.  
3. **Run the User Secrets commands** (shared via Slack) to set up Cloudinary credentials:  
   ```bash
   dotnet user-secrets set "Cloudinary:CloudName" "..."
   dotnet user-secrets set "Cloudinary:ApiKey" "..."
   dotnet user-secrets set "Cloudinary:ApiSecret" "..."
   ```
4. **Start the API and test the new endpoint:**  
   ```http
   PUT /api/UserProfile/{id}/image
   Content-Type: application/json

   {
     "imageLocation": "https://res.cloudinary.com/yourcloud/image/upload/.../profile.jpg"
   }
   ```
5. **Everything should work as expected!** No database migrations or additional setup are required.

---

## **Type of change**  
- [ ] Bug fix  
- [x] New feature  
- [ ] Refactor  
- [ ] Documentation update  
- [ ] Other (please describe)  

---

## **Checklist:**  
- [x] I have read the contributing guidelines.  
- [x] I have tested the changes.  
- [ ] I have updated the documentation (if applicable).  
- [ ] I have added relevant tests (if applicable).  
- [x] I have checked for any breaking changes.  

---
